### PR TITLE
Continue feedback on AWS signing

### DIFF
--- a/lib/awsv4/README.md
+++ b/lib/awsv4/README.md
@@ -7,3 +7,8 @@ The header.js file should be used for anything apart S3.
 This needs a lot of testing, the current way is to use localstack, which unfortunately turns out to
 be checking something about the authentication, but apparently not the signature as it doesn't
 matter what credential are used :(.
+
+## References
+
+- https://docs.aws.amazon.com/sagemaker/latest/APIReference/CommonParameters.html
+- https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html

--- a/lib/awsv4/core.js
+++ b/lib/awsv4/core.js
@@ -33,6 +33,7 @@ function createCanonicalRequest(
   ].join("\n");
 };
 exports.createCanonicalRequest = createCanonicalRequest;
+
 function createCanonicalURI(uri) {
   var url = uri;
   if (uri[uri.length - 1] == "/" && url[url.length - 1] != "/") {
@@ -40,7 +41,6 @@ function createCanonicalURI(uri) {
   }
   return url;
 }
-
 
 function queryParse(qs) {
   if (typeof qs !== 'string' || qs.length === 0) {
@@ -92,7 +92,6 @@ createCanonicalQueryString = createCanonicalQueryString;
 
 function createCanonicalHeaders(headers) {
   return Object.keys(headers)
-    .sort()
     .map(function (name) {
       var values = Array.isArray(headers[name])
         ? headers[name]
@@ -108,16 +107,17 @@ function createCanonicalHeaders(headers) {
         "\n"
       );
     })
+    .sort()
     .join("");
 };
 exports.createCanonicalHeaders = createCanonicalHeaders;
 
 function createSignedHeaders(headers) {
   return Object.keys(headers)
-    .sort()
     .map(function (name) {
       return name.toLowerCase().trim();
     })
+    .sort()
     .join(";");
 };
 exports.createSignedHeaders = createSignedHeaders;
@@ -150,8 +150,8 @@ function createAuthorizationHeader(
     "Signature=" + signature
   ].join(", ");
 };
-
 exports.createAuthorizationHeader = createAuthorizationHeader;
+
 function createSignature(
   secret,
   time,
@@ -248,6 +248,7 @@ exports.createPresignedURL = createPresignedURL;
 function toTime(time) {
   return new Date(time).toISOString().replace(/[:\-]|\.\d{3}/g, "");
 }
+exports.toTime = toTime;
 
 function toDate(time) {
   return toTime(time).substring(0, 8);

--- a/lib/awsv4/header.js
+++ b/lib/awsv4/header.js
@@ -1,4 +1,4 @@
-import { createSignedHeaders, createCredentialScope, createCanonicalRequest, createStringToSign, createSignature } from "./core.js"
+import { createSignedHeaders, createCredentialScope, createCanonicalRequest, createStringToSign, createSignature, toTime } from "./core.js"
 
 function fillOptions(options) {
   options = options || {};
@@ -19,33 +19,42 @@ function fillOptions(options) {
 function signWithHeaders(method, service, region = "", target = "", path = "", body = null, query = "", headers = {}) {
   var options = { headers: headers }
   options = fillOptions(options);
+  options.headers["X-Amz-Date"] = toTime(options.timestamp)
+  var host = service.concat(".", options.region, ".amazonaws.com")
+  options.headers["Host"] = host
+
+  if (options.sessionToken) {
+    options.headers["X-Amz-Security-Token"] = options.sessionToken
+  }
 
   if (target) {
     options.headers["X-Amz-Target"] = target;
   }
 
+  var svc = service.split(".").pop()
   var credential = options.key +
     "/" +
-    createCredentialScope(options.timestamp, region, service);
+    createCredentialScope(options.timestamp, options.region, svc);
   var signedHeaders = createSignedHeaders(options.headers);
   var signature = generateSignature(
-    service, method, path, query, body,
-    options.headers, options.doubleEscape, options.timestamp, region, options.secret);
+    svc, method, path, query, body,
+    options.headers, options.doubleEscape, options.timestamp, options.region, options.secret);
 
   var signatureHeader = "AWS4-HMAC-SHA256 Credential=".concat(
     credential,
-    " SignedHeaders=",
+    ", SignedHeaders=",
     signedHeaders,
-    " Signature=",
+    ", Signature=",
     signature,
   )
 
   options.headers["Authorization"] = signatureHeader;
+
   if (query != "") {
     query = "?" + query;
   }
-  var url = options.protocol.concat("://", service, ".", options.region, ".amazonaws.com/", path, query)
 
+  var url = options.protocol.concat("://", host, path, query)
   return {
     url: url,
     headers: options.headers,


### PR DESCRIPTION
I wouldn't call this ready to go just yet, but this is the first setup that actually works (for Sagemaker calls, at least).

There's still some work to be done to iron out the API. Perhaps we need to take a full endpoint (`scheme://fqdn/path?query`) as well as an AWS service name (e.g. `sagemaker`). I'm not sure.

In the current iteration, we are dropping _a lot_ more requests than in [my fork](https://github.com/Tapjoy/k6/commit/82cbee7e04e7407a2a3113f6abe938069d2a0c54) that uses the AWS go library for signing instead.

<details><summary>Load test using this JS library for request signing</summary>

```
data_received..................: 7.6 GB  13 MB/s
data_sent......................: 4.7 GB  7.9 MB/s
dropped_iterations.............: 4570646 7615.553268/s
http_req_blocked...............: avg=82.84µs  min=1.74µs  med=3.73µs   max=1.16s    p(90)=4.83µs   p(95)=5.32µs  
http_req_connecting............: avg=38.91µs  min=0s      med=0s       max=1.09s    p(90)=0s       p(95)=0s      
http_req_duration..............: avg=129.21ms min=1.55ms  med=136.42ms max=2.39s    p(90)=240.06ms p(95)=267.66ms
  { expected_response:true }...: avg=175.84ms min=3.8ms   med=176.98ms max=2.39s    p(90)=255.52ms p(95)=282.34ms
http_req_failed................: 31.89%  ✓ 774314 ✗ 1653475
http_req_receiving.............: avg=253.13µs min=13.42µs med=46.76µs  max=774.37ms p(90)=137.94µs p(95)=227.05µs
http_req_sending...............: avg=3.57ms   min=11.84µs med=21.96µs  max=508.03ms p(90)=115.46µs p(95)=10.52ms 
http_req_tls_handshaking.......: avg=33.99µs  min=0s      med=0s       max=486.81ms p(90)=0s       p(95)=0s      
http_req_waiting...............: avg=125.38ms min=1.51ms  med=133.96ms max=2.39s    p(90)=233.99ms p(95)=258.39ms
http_reqs......................: 2427789 4045.151704/s
iteration_duration.............: avg=153.76ms min=2.22ms  med=161.21ms max=2.42s    p(90)=274.46ms p(95)=320.53ms
iterations.....................: 2427789 4045.151704/s
vus............................: 1000    min=404  max=1000 
vus_max........................: 1000    min=404  max=1000 
```

</details>

<details><summary>Load test using AWS Go SDK for request signing</summary>

```
data_received..............: 2.8 GB  4.7 MB/s
data_sent..................: 7.7 GB  13 MB/s
dropped_iterations.........: 358253  597.013883/s
http_req_blocked...........: avg=14.81µs min=764ns   med=2.63µs  max=1.09s    p(90)=3.76µs  p(95)=4.36µs  
http_req_connecting........: avg=5.18µs  min=0s      med=0s      max=1s       p(90)=0s      p(95)=0s      
http_req_duration..........: avg=6.59ms  min=1.4ms   med=1.79ms  max=1.76s    p(90)=19.86ms p(95)=34.17ms 
http_req_receiving.........: avg=52.85µs min=11.75µs med=29.85µs max=211.34ms p(90)=53µs    p(95)=70.28µs 
http_req_sending...........: avg=947.8µs min=5.33µs  med=17.4µs  max=200.27ms p(90)=80.4µs  p(95)=398.59µs
http_req_tls_handshaking...: avg=5.63µs  min=0s      med=0s      max=212.08ms p(90)=0s      p(95)=0s      
http_req_waiting...........: avg=5.59ms  min=1.36ms  med=1.72ms  max=1.76s    p(90)=16.41ms p(95)=29.77ms 
http_reqs..................: 6641491 11067.771472/s
iteration_duration.........: avg=7.6ms   min=1.49ms  med=1.94ms  max=2.05s    p(90)=22.54ms p(95)=39.51ms 
iterations.................: 6641491 11067.771472/s
vus........................: 1000    min=57 max=1000
vus_max....................: 1000    min=57 max=1000
```

</details>

@MStoykov 